### PR TITLE
Cast some matrix sizes to type int.

### DIFF
--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -144,7 +144,11 @@ protected:
 
             depth = cvtest::randInt(rng) % (CV_64F+1);
             cn = cvtest::randInt(rng) % 4 + 1;
-            int sz[] = {cvtest::randInt(rng)%10+1, cvtest::randInt(rng)%10+1, cvtest::randInt(rng)%10+1};
+            int sz[] = {
+                static_cast<int>(cvtest::randInt(rng)%10+1),
+                static_cast<int>(cvtest::randInt(rng)%10+1),
+                static_cast<int>(cvtest::randInt(rng)%10+1),
+            };
             MatND test_mat_nd(3, sz, CV_MAKETYPE(depth, cn));
 
             rng0.fill(test_mat_nd, CV_RAND_UNI, Scalar::all(ranges[depth][0]), Scalar::all(ranges[depth][1]));
@@ -156,8 +160,12 @@ protected:
                 multiply(test_mat_nd, test_mat_scale, test_mat_nd);
             }
 
-            int ssz[] = {cvtest::randInt(rng)%10+1, cvtest::randInt(rng)%10+1,
-                cvtest::randInt(rng)%10+1,cvtest::randInt(rng)%10+1};
+            int ssz[] = {
+                static_cast<int>(cvtest::randInt(rng)%10+1),
+                static_cast<int>(cvtest::randInt(rng)%10+1),
+                static_cast<int>(cvtest::randInt(rng)%10+1),
+                static_cast<int>(cvtest::randInt(rng)%10+1),
+            };
             SparseMat test_sparse_mat = cvTsGetRandomSparseMat(4, ssz, cvtest::randInt(rng)%(CV_64F+1),
                                                                cvtest::randInt(rng) % 10000, 0, 100, rng);
 


### PR DESCRIPTION
Compiling OpenCV 2.4.9 with Clang++, I get a couple errors like:

    opencv-2.4.9/modules/core/test/test_io.cpp:147:25: error: 
          non-constant-expression cannot be narrowed from type 'unsigned int' to
          'int' in initializer list [-Wc++11-narrowing]
                int sz[] = {cvtest::randInt(rng)%10+1, cvtest::randInt(rng)%...
                            ^~~~~~~~~~~~~~~~~~~~~~~~~

This branch just casts the result of `randInt` to `int`. The cast is safe since the result is 1...10.